### PR TITLE
Update train.py to remove n_jobs

### DIFF
--- a/Code/src/training/train.py
+++ b/Code/src/training/train.py
@@ -119,7 +119,6 @@ def train(
         param_grid,
         cv=cv_folds,
         scoring='recall_weighted',
-        n_jobs=-1,
         verbose=1
     )
 


### PR DESCRIPTION
Removing n_jobs specifier since multithreading use seems to cause errors in grid search